### PR TITLE
feat: automatically merge PRs from transifex github app

### DIFF
--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: merge pull request
         id: mergePR
         env:
-          actorname: "${{ vars.GITHUB_ACTOR }}"
+          actorname: "${{ GITHUB_ACTOR }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         # if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -1,0 +1,20 @@
+# Automatically merge pull requests created by the "Transifex Integration" github app
+# https://github.com/apps/transifex-integration
+
+name: Automerge Transifex GH app PRs
+
+on:
+  - pull_request
+
+jobs:
+  automerge-transifex-app-pr:
+    # Merges the pull request
+    steps:
+      - name: merge pull request
+        id: mergePR
+        # env:
+        #   # This token requires Write access to the openedx-translations repo
+        #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
+        run: |
+          echo env.GITHUB_ACTOR
+          echo env.GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -14,10 +14,11 @@ jobs:
       - name: merge pull request
         id: mergePR
         env:
-          actorname: "${{ github.actor }}"
+          # secrets can't be used in job conditionals, so we set them to env here
+          TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ github.actor == secrets.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == 112954497 }}"
+        if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == 112954497 }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -21,7 +21,6 @@ jobs:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
-          # get the PR url
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,7 +17,7 @@ jobs:
           actorname: "${{ github.actor }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        # if: "${{ github.actor == 'brian-smith-tcril' }}"
+        if: "${{ github.actor == 'brian-smith-tcril' }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,7 +17,7 @@ jobs:
           actorname: "${{ github.actor }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ github.actor == 'brian-smith-tcril' }}"
+        if: "${{ github.actor == 'brian-smith-tcril' && github.actor_id == 112954497 }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: merge pull request
         id: mergePR
         env:
-          actorname: "${{ GITHUB_ACTOR }}"
+          actorname: "${{ env.GITHUB_ACTOR }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         # if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -16,7 +16,7 @@ jobs:
         # env:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ vars.GITHUB_ACTOR == brian-smith-tcril }}"
+        if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"
         run: |
           echo $GITHUB_ACTOR
           echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -20,6 +20,9 @@ jobs:
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
           ghrefname: ${{ github.ref_name }}
+          ghheadref: ${{ github.head_ref }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
         # run: gh pr merge ${{ env.PR_URL }} --merge --auto
-        run: echo $ghrefname
+        run: |
+          echo $ghrefname
+          echo $ghheadref

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -19,7 +19,7 @@ jobs:
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-          gheventpr: ${{ github.event.pull_request }}
+          ghrefname: ${{ github.ref_name }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
         # run: gh pr merge ${{ env.PR_URL }} --merge --auto
-        run: echo $gheventpr
+        run: echo $ghrefname

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   automerge-transifex-app-pr:
+    runs-on: ubuntu-latest
     # Merges the pull request
     steps:
       - name: merge pull request

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,5 +17,5 @@ jobs:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         run: |
-          echo ${{ env.GITHUB_ACTOR }}
-          echo ${{ env.GITHUB_ACTOR_ID }}
+          echo ${{ vars.GITHUB_ACTOR }}
+          echo ${{ vars.GITHUB_ACTOR_ID }}

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,5 +17,5 @@ jobs:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         run: |
-          echo ${{ vars.GITHUB_ACTOR }}
-          echo ${{ vars.GITHUB_ACTOR_ID }}
+          echo $GITHUB_ACTOR
+          echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -16,7 +16,7 @@ jobs:
         # env:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "{{ $GITHUB_ACTOR == brian-smith-tcril }}"
+        if: "${{ $GITHUB_ACTOR == brian-smith-tcril }}"
         run: |
           echo $GITHUB_ACTOR
           echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - name: merge pull request
         id: mergePR
-        # env:
+        env:
+          actorname: "${{ github.actor }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ github.actor == 'brian-smith-tcril' }}"
+        # if: "${{ github.actor == 'brian-smith-tcril' }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -19,10 +19,5 @@ jobs:
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-          ghrefname: ${{ github.ref_name }}
-          ghheadref: ${{ github.head_ref }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        # run: gh pr merge ${{ env.PR_URL }} --merge --auto
-        run: |
-          echo $ghrefname
-          echo $ghheadref
+        run: gh pr merge ${{ github.head_ref }} --merge --auto

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,5 +17,5 @@ jobs:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         run: |
-          echo $env.GITHUB_ACTOR
-          echo $env.GITHUB_ACTOR_ID
+          echo ${{ env.GITHUB_ACTOR }}
+          echo ${{ env.GITHUB_ACTOR_ID }}

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -13,10 +13,12 @@ jobs:
     steps:
       - name: merge pull request
         id: mergePR
-        # env:
+        env:
+          actorname: "${{ vars.GITHUB_ACTOR }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"
+        # if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"
         run: |
+          echo $actorname
           echo $GITHUB_ACTOR
           echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -16,6 +16,7 @@ jobs:
         # env:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
+        if: "{{ $GITHUB_ACTOR == brian-smith-tcril }}"
         run: |
           echo $GITHUB_ACTOR
           echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,7 +17,7 @@ jobs:
           actorname: "${{ github.actor }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ github.actor == 'brian-smith-tcril' && github.actor_id == 112954497 }}"
+        if: "${{ github.actor == secrets.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == 112954497 }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -13,11 +13,10 @@ jobs:
     steps:
       - name: merge pull request
         id: mergePR
-        env:
-          actorname: "${{ env.GITHUB_ACTOR }}"
+        # env:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        # if: "${{ vars.GITHUB_ACTOR == 'brian-smith-tcril' }}"
+        if: "${{ github.actor == 'brian-smith-tcril' }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -11,13 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     # Merges the pull request
     steps:
+      - name: clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: merge pull request
         id: mergePR
         env:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
+          # get the PR url
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        run: gh pr merge ${{ github.head_ref }} --merge --auto
+        run: gh pr merge ${{ github.head_ref }} --rebase --auto

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -16,7 +16,7 @@ jobs:
         # env:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ $GITHUB_ACTOR == brian-smith-tcril }}"
+        if: "${{ vars.GITHUB_ACTOR == brian-smith-tcril }}"
         run: |
           echo $GITHUB_ACTOR
           echo $GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,7 +17,7 @@ jobs:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
-        #   # This token requires Write access to the openedx-translations repo
-        #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
+          # This token requires Write access to the openedx-translations repo
+          GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
         run: gh pr merge ${{ env.PR_URL }} --merge --auto

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -17,5 +17,5 @@ jobs:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         run: |
-          echo env.GITHUB_ACTOR
-          echo env.GITHUB_ACTOR_ID
+          echo $env.GITHUB_ACTOR
+          echo $env.GITHUB_ACTOR_ID

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -19,5 +19,7 @@ jobs:
           TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
           # This token requires Write access to the openedx-translations repo
           GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
+          gheventpr: ${{ github.event.pull_request }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        run: gh pr merge ${{ env.PR_URL }} --merge --auto
+        # run: gh pr merge ${{ env.PR_URL }} --merge --auto
+        run: echo $gheventpr

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -20,7 +20,4 @@ jobs:
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
         if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
-        run: |
-          echo $actorname
-          echo $GITHUB_ACTOR
-          echo $GITHUB_ACTOR_ID
+        run: gh pr merge ${{ env.PR_URL }} --merge --auto

--- a/.github/workflows/automerge-transifex-app-prs.yml
+++ b/.github/workflows/automerge-transifex-app-prs.yml
@@ -16,9 +16,10 @@ jobs:
         env:
           # secrets can't be used in job conditionals, so we set them to env here
           TRANSIFEX_APP_ACTOR_NAME: "${{ secrets.TRANSIFEX_APP_ACTOR_NAME }}"
+          TRANSIFEX_APP_ACTOR_ID: "${{ secrets.TRANSIFEX_APP_ACTOR_ID }}"
         #   # This token requires Write access to the openedx-translations repo
         #   GITHUB_TOKEN: ${{ secrets.EDX_TRANSIFEX_BOT_GITHUB_TOKEN }}
-        if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == 112954497 }}"
+        if: "${{ github.actor == env.TRANSIFEX_APP_ACTOR_NAME && github.actor_id == env.TRANSIFEX_APP_ACTOR_ID }}"
         run: |
           echo $actorname
           echo $GITHUB_ACTOR


### PR DESCRIPTION
The CLA check prevents the [transifex github app](https://github.com/apps/transifex-integration) from committing directly, so we have configured it to create PRs instead. This adds a workflow to automatically merge those PRs.

This is done by checking `github.actor` and `github.actor_id` ([docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)) against the repository secret values `TRANSIFEX_APP_ACTOR_NAME` and `TRANSIFEX_APP_ACTOR_ID`, and running `gh pr merge` if they match.