### PR TITLE
chore: add workflow to verify PR actor name and id

### DIFF
--- a/.github/workflows/echo-actor-name-and-id.yml
+++ b/.github/workflows/echo-actor-name-and-id.yml
@@ -13,4 +13,4 @@ jobs:
       - name: echo actor name and id
         run: |
           echo $GITHUB_ACTOR
-          echo GITHUB_ACTOR_ID
+          echo $GITHUB_ACTOR_ID

--- a/.github/workflows/echo-actor-name-and-id.yml
+++ b/.github/workflows/echo-actor-name-and-id.yml
@@ -1,0 +1,16 @@
+# Get the `github.actor` and `github.actor_id` from the "Transifex Integration" github app
+# https://github.com/apps/transifex-integration
+
+name: Echo actor name and id
+
+on:
+  - pull_request
+
+jobs:
+  echo-actor-name-id:
+    runs-on: ubuntu-latest
+    steps:
+      - name: echo actor name and id
+        run: |
+          echo $GITHUB_ACTOR
+          echo GITHUB_ACTOR_ID


### PR DESCRIPTION
This adds a temporary workflow to get the actor name and ID for use in implementing automerge functionality. This will be removed as a part of the automerge PR.